### PR TITLE
Material-UI (MUI) のインストールと設定

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import MUIProvider from './providers/MUIProvider';
 
 export const metadata: Metadata = {
   title: '広告アノテーションツール',
@@ -14,9 +15,11 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="min-h-screen bg-gray-50">
-        <main className="container mx-auto px-4 py-8">
-          {children}
-        </main>
+        <MUIProvider>
+          <main className="container mx-auto px-4 py-8">
+            {children}
+          </main>
+        </MUIProvider>
       </body>
     </html>
   );

--- a/app/providers/MUIProvider.tsx
+++ b/app/providers/MUIProvider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import theme from '@/src/theme';
+
+interface MUIProviderProps {
+  children: ReactNode;
+}
+
+export default function MUIProvider({ children }: MUIProviderProps) {
+  return (
+    <ThemeProvider theme={theme}>
+      {/* CssBaselineはMUIの基本スタイルリセットを提供しますが、 */}
+      {/* Tailwindとの併用を考慮して慎重に使用します */}
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.4",
+    "@mui/icons-material": "^5.15.14",
+    "@mui/material": "^5.15.14",
     "file-type": "^20.5.0",
     "next": "^14.1.0",
     "react": "^18.2.0",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,125 @@
+import { createTheme } from '@mui/material/styles';
+
+// アプリケーションのカラーパレットを定義
+const palette = {
+  primary: {
+    main: '#3f51b5', // メインカラー（青系）
+    light: '#757de8',
+    dark: '#002984',
+  },
+  secondary: {
+    main: '#f50057', // アクセントカラー（ピンク系）
+    light: '#ff5983',
+    dark: '#bb002f',
+  },
+  error: {
+    main: '#f44336',
+  },
+  warning: {
+    main: '#ff9800',
+  },
+  info: {
+    main: '#2196f3',
+  },
+  success: {
+    main: '#4caf50',
+  },
+  background: {
+    default: '#f5f5f5',
+    paper: '#ffffff',
+  },
+  text: {
+    primary: 'rgba(0, 0, 0, 0.87)',
+    secondary: 'rgba(0, 0, 0, 0.54)',
+    disabled: 'rgba(0, 0, 0, 0.38)',
+  },
+};
+
+// タイポグラフィの設定
+const typography = {
+  fontFamily: [
+    'Roboto',
+    '"Helvetica Neue"',
+    'Arial',
+    'sans-serif',
+    '-apple-system',
+    'BlinkMacSystemFont',
+    '"Segoe UI"',
+    '"Hiragino Kaku Gothic ProN"',
+    '"Hiragino Sans"',
+    'Meiryo',
+    'sans-serif',
+  ].join(','),
+  h1: {
+    fontSize: '2.5rem',
+    fontWeight: 500,
+  },
+  h2: {
+    fontSize: '2rem',
+    fontWeight: 500,
+  },
+  h3: {
+    fontSize: '1.5rem',
+    fontWeight: 500,
+  },
+  h4: {
+    fontSize: '1.25rem',
+    fontWeight: 500,
+  },
+  h5: {
+    fontSize: '1rem',
+    fontWeight: 500,
+  },
+  h6: {
+    fontSize: '0.875rem',
+    fontWeight: 500,
+  },
+  button: {
+    textTransform: 'none', // ボタンのテキストを大文字に変換しない
+  },
+};
+
+// MUIテーマを作成
+const theme = createTheme({
+  palette,
+  typography,
+  components: {
+    // ボタンのカスタマイズ
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          textTransform: 'none',
+          fontWeight: 500,
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: '0px 2px 4px -1px rgba(0,0,0,0.2)',
+          },
+        },
+      },
+    },
+    // カードのカスタマイズ
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.05)',
+        },
+      },
+    },
+    // 入力フィールドのカスタマイズ
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 4,
+          },
+        },
+      },
+    },
+  },
+});
+
+export default theme;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,4 +9,7 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  corePlugins: {
+    preflight: false, // MUIとの競合を避けるためpreflightを無効化
+  },
 };


### PR DESCRIPTION
## 変更内容
このPRでは、Material-UI (MUI)を導入し、アプリケーション全体で使用できるようセットアップしています。

### 実装したこと
1. MUI関連パッケージを追加
   - `@mui/material`: MUIのコアコンポーネント
   - `@mui/icons-material`: アイコンライブラリ
   - `@emotion/react`と`@emotion/styled`: MUIのスタイリングエンジン

2. MUIテーマの作成
   - `src/theme/index.ts`にアプリケーション全体のテーマ設定を実装
   - カラーパレット、タイポグラフィ、コンポーネントスタイルをカスタマイズ

3. MUIとTailwindの共存設定
   - Tailwindの`preflight`を無効化して基本スタイルの競合を回避
   - 両フレームワークのメリットを活かせる構成に

4. Next.jsとの統合
   - `MUIProvider`をクライアントコンポーネントとして実装
   - アプリケーションのレイアウトに統合

## 関連Issue
Issue #11: 依存関係の更新: Material-UI (MUI) のインストールと設定

## 動作確認方法
1. 依存関係をインストール: `npm install`
2. 開発サーバーを起動: `npm run dev`
3. アプリケーションにアクセスし、UIの表示を確認

## 備考
- 今後のコンポーネント開発では、TailwindとMUIを併用して最適なUIを構築できます
- コンポーネントのリファクタリング時には、MUIコンポーネントへの段階的な移行を検討できます